### PR TITLE
Custom configuration to override the generated OpenAPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build
 tsconfig.tsbuildinfo
 
 # misc
+.idea
 .DS_Store
 
 # logs

--- a/README.md
+++ b/README.md
@@ -46,6 +46,37 @@ This generator is used via the [Fern CLI](https://github.com/fern-api/fern) by d
 
 By default, Fern runs the generators in the cloud. To run a generator on your local machine, use the `--local` flag for `fern generate`. This will run the generator locally in a Docker container, allowing you to inspect its logs and output. [Read more.](https://buildwithfern.com/docs/compiler/cli-reference#running-locally)
 
+## Configuration
+
+You can customize the behavior of generators in `generators.yml`:
+
+```yml
+default-group: local
+groups:
+  local:
+    generators:
+      - name: fernapi/fern-openapi
+        version: 0.0.27
+        config: # <--
+          format: json
+```
+
+#### ✨ `format`
+
+**Type:** enum<string>: 'json' | 'yaml'
+
+**Default:** `yaml`
+
+When configured, the generator outputs OAS files in the specified format.
+
+#### ✨ `customOverrides`
+
+**Type:** object
+
+**Default:** {}
+
+When configured, the object is merged into the generated OAS file. This allows you to add custom fields to the specification.
+
 ## Releases
 
 All generator releases are published in the [Releases section of the GitHub repository](https://github.com/fern-api/fern-openapi/releases). You can directly use these version numbers in your generator configuration files.

--- a/src/__test__/__snapshots__/convertToOpenApi.test.ts.snap
+++ b/src/__test__/__snapshots__/convertToOpenApi.test.ts.snap
@@ -1,7 +1,62 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`convertToOpenApi any-auth 1`] = `
-"openapi: 3.0.1
+"components:
+  securitySchemes:
+    foo:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://foo.bar
+          scopes:
+            read: Grants read access
+            write: Grants write access
+          x-google-audiences: foo-bar
+          x-google-issuer: https://securetoken.google.com/foo-bar
+          x-google-jwks_uri: >-
+            https://www.googleapis.com/service_accounts/v1/metadata/x509/securetoken@system.gserviceaccount.com
+    BearerAuth:
+      type: http
+      scheme: bearer
+    BasicAuth:
+      type: http
+      scheme: basic
+    HeaderAuthAuth:
+      type: apiKey
+      in: header
+      name: My-Header
+  schemas:
+    PostId:
+      title: PostId
+      type: string
+    Author:
+      title: Author
+      type: object
+      properties:
+        name:
+          type: string
+      required:
+        - name
+    BlogPost:
+      title: BlogPost
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/PostId'
+        title:
+          type: string
+          example: My Post
+        author:
+          $ref: '#/components/schemas/Author'
+        content:
+          type: string
+          example: This is my post.
+      required:
+        - id
+        - title
+        - author
+        - content
+openapi: 3.0.1
 info:
   title: fern
   version: ''
@@ -59,59 +114,24 @@ paths:
                     author:
                       name: Fernie
                     content: This is my post.
-components:
-  schemas:
-    PostId:
-      title: PostId
-      type: string
-    Author:
-      title: Author
-      type: object
-      properties:
-        name:
-          type: string
-      required:
-        - name
-    BlogPost:
-      title: BlogPost
-      type: object
-      properties:
-        id:
-          $ref: '#/components/schemas/PostId'
-        title:
-          type: string
-          example: My Post
-        author:
-          $ref: '#/components/schemas/Author'
-        content:
-          type: string
-          example: This is my post.
-      required:
-        - id
-        - title
-        - author
-        - content
-  securitySchemes:
-    BearerAuth:
-      type: http
-      scheme: bearer
-    BasicAuth:
-      type: http
-      scheme: basic
-    HeaderAuthAuth:
-      type: apiKey
-      in: header
-      name: My-Header
 "
 `;
 
 exports[`convertToOpenApi base-properties 1`] = `
-"openapi: 3.0.1
-info:
-  title: fern
-  version: ''
-paths: {}
-components:
+"components:
+  securitySchemes:
+    foo:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://foo.bar
+          scopes:
+            read: Grants read access
+            write: Grants write access
+          x-google-audiences: foo-bar
+          x-google-issuer: https://securetoken.google.com/foo-bar
+          x-google-jwks_uri: >-
+            https://www.googleapis.com/service_accounts/v1/metadata/x509/securetoken@system.gserviceaccount.com
   schemas:
     MyObject:
       title: MyObject
@@ -150,12 +170,31 @@ components:
       properties:
         base:
           type: integer
-  securitySchemes: {}
+openapi: 3.0.1
+info:
+  title: fern
+  version: ''
+paths: {}
 "
 `;
 
 exports[`convertToOpenApi file-upload 1`] = `
-"openapi: 3.0.1
+"components:
+  securitySchemes:
+    foo:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://foo.bar
+          scopes:
+            read: Grants read access
+            write: Grants write access
+          x-google-audiences: foo-bar
+          x-google-issuer: https://securetoken.google.com/foo-bar
+          x-google-jwks_uri: >-
+            https://www.googleapis.com/service_accounts/v1/metadata/x509/securetoken@system.gserviceaccount.com
+  schemas: {}
+openapi: 3.0.1
 info:
   title: fern
   version: ''
@@ -182,14 +221,26 @@ paths:
                 heroImage:
                   type: string
                   format: binary
-components:
-  schemas: {}
-  securitySchemes: {}
 "
 `;
 
 exports[`convertToOpenApi multiple-environment-urls 1`] = `
-"openapi: 3.0.1
+"components:
+  securitySchemes:
+    foo:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://foo.bar
+          scopes:
+            read: Grants read access
+            write: Grants write access
+          x-google-audiences: foo-bar
+          x-google-issuer: https://securetoken.google.com/foo-bar
+          x-google-jwks_uri: >-
+            https://www.googleapis.com/service_accounts/v1/metadata/x509/securetoken@system.gserviceaccount.com
+  schemas: {}
+openapi: 3.0.1
 info:
   title: fern
   version: ''
@@ -207,14 +258,127 @@ paths:
         - url: https://foo.buildwithfern.com
         - url: https://foo-dev.buildwithfern.com
           description: i'm dev!
-components:
-  schemas: {}
-  securitySchemes: {}
 "
 `;
 
 exports[`convertToOpenApi test-api 1`] = `
-"openapi: 3.0.1
+"components:
+  securitySchemes:
+    foo:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://foo.bar
+          scopes:
+            read: Grants read access
+            write: Grants write access
+          x-google-audiences: foo-bar
+          x-google-issuer: https://securetoken.google.com/foo-bar
+          x-google-jwks_uri: >-
+            https://www.googleapis.com/service_accounts/v1/metadata/x509/securetoken@system.gserviceaccount.com
+  schemas:
+    folderNestedType:
+      title: folderNestedType
+      type: string
+    OptionalString:
+      title: OptionalString
+      type: string
+      nullable: true
+    AliasOfNestedType:
+      title: AliasOfNestedType
+      $ref: '#/components/schemas/folderNestedType'
+    PostId:
+      title: PostId
+      type: string
+    BlogPost:
+      title: BlogPost
+      type: object
+      description: A blog post
+      properties:
+        id:
+          $ref: '#/components/schemas/PostId'
+        type:
+          $ref: '#/components/schemas/PostType'
+        title:
+          type: string
+          example: My blog post
+        author:
+          $ref: '#/components/schemas/Author'
+        content:
+          type: string
+          example: This is my short post!
+      required:
+        - id
+        - type
+        - title
+        - author
+        - content
+    PostType:
+      title: PostType
+      type: string
+      enum:
+        - LONG
+        - SHORT
+    Author:
+      title: Author
+      oneOf:
+        - type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - anonymous
+          required:
+            - type
+        - type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - name
+            value:
+              type: string
+          required:
+            - type
+        - type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - type
+            value:
+              $ref: '#/components/schemas/PostType'
+          required:
+            - type
+    PostNotFoundErrorBody:
+      title: PostNotFoundErrorBody
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/PostId'
+      required:
+        - id
+    CreatePostRequest:
+      title: CreatePostRequest
+      type: object
+      properties:
+        title:
+          type: string
+          example: My Blog
+        author:
+          $ref: '#/components/schemas/Author'
+          description: Author is the writer.
+        content:
+          type: string
+          example: I'm a post
+        postType:
+          $ref: '#/components/schemas/PostType'
+      required:
+        - title
+        - author
+        - content
+        - postType
+openapi: 3.0.1
 info:
   title: fern
   version: ''
@@ -334,110 +498,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreatePostRequest'
-components:
-  schemas:
-    folderNestedType:
-      title: folderNestedType
-      type: string
-    OptionalString:
-      title: OptionalString
-      type: string
-      nullable: true
-    AliasOfNestedType:
-      title: AliasOfNestedType
-      $ref: '#/components/schemas/folderNestedType'
-    PostId:
-      title: PostId
-      type: string
-    BlogPost:
-      title: BlogPost
-      type: object
-      description: A blog post
-      properties:
-        id:
-          $ref: '#/components/schemas/PostId'
-        type:
-          $ref: '#/components/schemas/PostType'
-        title:
-          type: string
-          example: My blog post
-        author:
-          $ref: '#/components/schemas/Author'
-        content:
-          type: string
-          example: This is my short post!
-      required:
-        - id
-        - type
-        - title
-        - author
-        - content
-    PostType:
-      title: PostType
-      type: string
-      enum:
-        - LONG
-        - SHORT
-    Author:
-      title: Author
-      oneOf:
-        - type: object
-          properties:
-            type:
-              type: string
-              enum:
-                - anonymous
-          required:
-            - type
-        - type: object
-          properties:
-            type:
-              type: string
-              enum:
-                - name
-            value:
-              type: string
-          required:
-            - type
-        - type: object
-          properties:
-            type:
-              type: string
-              enum:
-                - type
-            value:
-              $ref: '#/components/schemas/PostType'
-          required:
-            - type
-    PostNotFoundErrorBody:
-      title: PostNotFoundErrorBody
-      type: object
-      properties:
-        id:
-          $ref: '#/components/schemas/PostId'
-      required:
-        - id
-    CreatePostRequest:
-      title: CreatePostRequest
-      type: object
-      properties:
-        title:
-          type: string
-          example: My Blog
-        author:
-          $ref: '#/components/schemas/Author'
-          description: Author is the writer.
-        content:
-          type: string
-          example: I'm a post
-        postType:
-          $ref: '#/components/schemas/PostType'
-      required:
-        - title
-        - author
-        - content
-        - postType
-  securitySchemes: {}
 servers:
   - url: https://buildwithfern.com
     description: prod

--- a/src/__test__/convertToOpenApi.test.ts
+++ b/src/__test__/convertToOpenApi.test.ts
@@ -25,7 +25,30 @@ describe("convertToOpenApi", () => {
                     publish: undefined,
                     workspaceName: "fern",
                     organization: "fern",
-                    customConfig: undefined,
+                    customConfig: {
+                        customOverrides: {
+                            components: {
+                                securitySchemes: {
+                                    foo: {
+                                        type: "oauth2",
+                                        flows: {
+                                            implicit: {
+                                                authorizationUrl: "https://foo.bar",
+                                                scopes: {
+                                                    read: "Grants read access",
+                                                    write: "Grants write access",
+                                                },
+                                                "x-google-audiences": "foo-bar",
+                                                "x-google-issuer": "https://securetoken.google.com/foo-bar",
+                                                "x-google-jwks_uri":
+                                                    "https://www.googleapis.com/service_accounts/v1/metadata/x509/securetoken@system.gserviceaccount.com",
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
                     environment: GeneratorEnvironment.local(),
                 };
 
@@ -42,7 +65,7 @@ describe("convertToOpenApi", () => {
 
                 expect(openApi).toMatchSnapshot();
             },
-            90_000
+            90_000,
         );
     }
 });

--- a/src/customConfig.ts
+++ b/src/customConfig.ts
@@ -2,10 +2,12 @@ import { GeneratorConfig } from "@fern-fern/generator-exec-client/model/config";
 
 export interface FernOpenapiCustomConfig {
     format: "yaml" | "json";
+    customOverrides: {};
 }
 
 const DEFAULT_FERN_OPENAPI_CUSTOM_CONFIG: FernOpenapiCustomConfig = {
     format: "yaml",
+    customOverrides: {},
 };
 
 export function getCustomConfig(generatorConfig: GeneratorConfig): FernOpenapiCustomConfig {


### PR DESCRIPTION
Implements #120. This simple approach to implementing an `override` config has a couple of drawbacks: 

1. It does not enforce compliance with the OAS specs
2. Only supports a _raw_ merging strategy

On the plus side, it's very simple.